### PR TITLE
fix: function name error for branch_var()

### DIFF
--- a/src/cdcl_solver.py
+++ b/src/cdcl_solver.py
@@ -127,7 +127,7 @@ class CDCLSolver:
         while True:
             if all(self.assign_val[i] != 0 for i in range(1, self.num_vars+1)):
                 return True
-            var = self.pick_branch_var()
+            var = self.branch_var()
             if var is None:
                 return True
             self.level += 1


### PR DESCRIPTION
While running `cdcl_solver.py`, I encountered a error:
AttributeError: 'CDCLSolver' object has no attribute 'pick_branch_var'

It seems that the function name is not correct! I change it to `branch_var`, then it works.
Probably a typo.